### PR TITLE
style(CSS): add support for stylelint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,8 +23,12 @@ indent_style = space
 indent_size = 2
 
 [*.css]
-indent_style = space
-indent_size = 2
+indent_style = tab
+indent_size = 4
+
+[*.scss]
+indent_style = tab
+indent_size = 4
 
 [*.html]
 indent_style = space

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -8,6 +8,5 @@
   "declaration-block-semicolon-newline-after": "always",
   "declaration-block-trailing-semicolon": "always",
   "block-closing-brace-newline-after": "always",
-  "selector-attribute-brackets-space-inside": "never",
-  "selector-no-id": false
+  "selector-attribute-brackets-space-inside": "never"
 }

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,13 @@
+"rules": {
+  "font-family-name-quotes": "double-unless-keyword",
+  "max-nesting-depth": 4,
+  "string-quotes": "double",
+  "declaration-bang-space-before": "always",
+  "declaration-bang-space-after": "never",
+  "declaration-colon-space-after": "always",
+  "declaration-block-semicolon-newline-after": "always",
+  "declaration-block-trailing-semicolon": "always",
+  "block-closing-brace-newline-after": "always",
+  "selector-attribute-brackets-space-inside": "never",
+  "selector-no-id": false
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ember-cli-release": "0.2.8",
     "ember-cli-sass": "^5.3.0",
     "ember-cli-sri": "^2.0.0",
+    "ember-cli-style-lint": "0.1.3",
     "ember-cli-uglify": "^1.2.0",
     "ember-cli-windows-addon": "1.3.1",
     "ember-data": "2.3.3",


### PR DESCRIPTION
To use this feature in your Atom Editor, the following packages are required:
- Atom Linter (https://github.com/steelbrain/atom-linter)
- Atom lint-stylelint (https://github.com/AtomLinter/linter-stylelint)