### PR TITLE
fix(leaderboard): fix collapsed leaderboard items

### DIFF
--- a/app/styles/_leaderboard.scss
+++ b/app/styles/_leaderboard.scss
@@ -18,6 +18,7 @@
 	.leaderboard_list {
     position: relative;
     font-size: 18px;
+    width: 100%;
 
 		.list-item {
       .img_container {


### PR DESCRIPTION
**Before**
<img width="571" alt="screen shot 2016-07-02 at 00 34 42" src="https://cloud.githubusercontent.com/assets/3121574/16536069/b9fe0834-3fed-11e6-880e-d5400c104501.png">

**After**
<img width="561" alt="screen shot 2016-07-02 at 00 36 52" src="https://cloud.githubusercontent.com/assets/3121574/16536072/c369568a-3fed-11e6-852e-82619413d6b6.png">
